### PR TITLE
[AF-175] Fix z-index issue occuring when drawing first edge

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "build": "turbo run build",
-    "dev": "turbo watch dev --filter=!docs",
+    "dev": "NODE_ENV=development turbo watch dev --filter=!docs",
     "docs:dev": "turbo watch docs:dev",
     "lint:check": "turbo run lint:check",
     "lint:fix": "turbo run lint:fix",

--- a/packages/core/src/middleware-manager/middlewares/z-index-assignment/z-index-assignment.ts
+++ b/packages/core/src/middleware-manager/middlewares/z-index-assignment/z-index-assignment.ts
@@ -110,9 +110,10 @@ export const zIndexMiddleware: Middleware<'z-index', ZIndexMiddlewareMetadata> =
       nodesToUpdate.push({ id: node.id, zIndex: node.zIndex });
     }
 
+    const addedEdge = edges.at(-1);
     // Partial for Edge
-    if (isEdgeAdded) {
-      edgesWithZIndex = assignEdgesZIndex([edges[edges.length - 1]], nodesWithZIndex, nodesMap);
+    if (isEdgeAdded && addedEdge) {
+      edgesWithZIndex = assignEdgesZIndex([addedEdge], nodesWithZIndex, nodesMap);
     }
 
     if (shouldSnapEdge) {


### PR DESCRIPTION
- Fix the issue with NgDiagram breaking when drawing the first edge on the diagram
- Add `NODE_ENV=development` to `dev` command to get source maps work independently from user's node settings