### PR TITLE
[AD-284] Add internalId assignment middleware to force node recreation

### DIFF
--- a/apps/docs/src/components/angular/examples/transactions/diagram.component.ts
+++ b/apps/docs/src/components/angular/examples/transactions/diagram.component.ts
@@ -58,6 +58,7 @@ export class NgDiagramComponentContainer {
 
   config: NgDiagramConfig = {
     debugMode: true,
+    edgeRouting: { defaultRouting: 'orthogonal' },
   };
 
   model = initializeModel({
@@ -84,7 +85,6 @@ export class NgDiagramComponentContainer {
   }
 
   private createDiagram(nodeName: string) {
-    // Transaction example: All operations are batched together
     this.modelService.addNodes([
       {
         id: '1',
@@ -103,7 +103,6 @@ export class NgDiagramComponentContainer {
       },
     ]);
 
-    // Update node data within the same transaction
     this.modelService.updateNodeData('1', {
       label: `Updated ${nodeName} 1`,
     });
@@ -113,6 +112,25 @@ export class NgDiagramComponentContainer {
     this.modelService.updateNodeData('3', {
       label: `Updated ${nodeName} 3`,
     });
+
+    this.modelService.addEdges([
+      {
+        id: 'edge-1',
+        source: '1',
+        target: '2',
+        sourcePort: 'port-right',
+        targetPort: 'port-left',
+        data: {},
+      },
+      {
+        id: 'edge-2',
+        source: '2',
+        target: '3',
+        sourcePort: 'port-right',
+        targetPort: 'port-left',
+        data: {},
+      },
+    ]);
   }
 
   private cleanDiagram() {

--- a/apps/docs/src/content/docs/api/Other/createMiddlewares.md
+++ b/apps/docs/src/content/docs/api/Other/createMiddlewares.md
@@ -14,7 +14,7 @@ Allows modifying the default middleware chain by removing, replacing, or adding 
 
 ### TMiddlewares
 
-`TMiddlewares` *extends* [`MiddlewareChain`](/docs/api/types/middlewarechain/) = \[[`Middleware`](/docs/api/types/middleware/)\<`"z-index"`\>, [`Middleware`](/docs/api/types/middleware/)\<`string`\>, [`Middleware`](/docs/api/types/middleware/)\<`string`\>\]
+`TMiddlewares` *extends* [`MiddlewareChain`](/docs/api/types/middlewarechain/) = \[[`Middleware`](/docs/api/types/middleware/)\<`string`\>, [`Middleware`](/docs/api/types/middleware/)\<`"z-index"`\>, [`Middleware`](/docs/api/types/middleware/)\<`string`\>, [`Middleware`](/docs/api/types/middleware/)\<`string`\>\]
 
 The type of the resulting middleware chain
 

--- a/packages/ng-diagram/projects/ng-diagram/src/core/src/middleware-manager/middlewares/index.ts
+++ b/packages/ng-diagram/projects/ng-diagram/src/core/src/middleware-manager/middlewares/index.ts
@@ -1,3 +1,4 @@
 export * from './edges-routing/edges-routing';
+export * from './internal-id-assignment/internal-id-assignment';
 export * from './logger/logger';
 export * from './z-index-assignment/z-index-assignment';

--- a/packages/ng-diagram/projects/ng-diagram/src/core/src/middleware-manager/middlewares/internal-id-assignment/internal-id-assignment.test.ts
+++ b/packages/ng-diagram/projects/ng-diagram/src/core/src/middleware-manager/middlewares/internal-id-assignment/internal-id-assignment.test.ts
@@ -1,0 +1,297 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MiddlewareContext } from '../../../types';
+import { internalIdMiddleware } from './internal-id-assignment';
+
+let originalCrypto: Crypto | undefined;
+
+describe('InternalIdMiddleware', () => {
+  let context: MiddlewareContext;
+  let nextMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    // Ensure crypto.randomUUID exists in test environment
+    originalCrypto = globalThis.crypto as Crypto | undefined;
+    if (!originalCrypto || typeof originalCrypto.randomUUID !== 'function') {
+      // @ts-expect-error Partial stub for tests
+      globalThis.crypto = {
+        // Return a valid RFC4122 v4 UUID string
+        randomUUID: vi.fn().mockReturnValue('550e8400-e29b-41d4-a716-446655440000'),
+      } as Crypto;
+    }
+
+    nextMock = vi.fn();
+
+    context = {
+      modelActionType: 'addNodes',
+      initialState: {
+        nodes: [],
+        edges: [],
+        metadata: { viewport: { x: 0, y: 0, scale: 1 } },
+      },
+      state: {
+        nodes: [],
+        edges: [],
+        metadata: { viewport: { x: 0, y: 0, scale: 1 } },
+      },
+      nodesMap: new Map(),
+      edgesMap: new Map(),
+      initialNodesMap: new Map(),
+      initialEdgesMap: new Map(),
+      initialUpdate: {},
+      history: [],
+      helpers: {
+        anyNodesAdded: vi.fn().mockReturnValue(false),
+        anyEdgesAdded: vi.fn().mockReturnValue(false),
+        checkIfAnyNodePropsChanged: vi.fn().mockReturnValue(false),
+        checkIfAnyEdgePropsChanged: vi.fn().mockReturnValue(false),
+        getAffectedNodeIds: vi.fn().mockReturnValue([]),
+        getAffectedEdgeIds: vi.fn().mockReturnValue([]),
+      },
+    } as unknown as MiddlewareContext;
+  });
+
+  afterEach(() => {
+    // Restore original crypto if we replaced it
+    if (originalCrypto) {
+      globalThis.crypto = originalCrypto;
+      originalCrypto = undefined;
+    }
+  });
+
+  it('should not modify state when no nodes are added', async () => {
+    context.helpers.anyNodesAdded = vi.fn().mockReturnValue(false);
+
+    await internalIdMiddleware.execute(context, nextMock, () => null);
+
+    expect(nextMock).toHaveBeenCalledWith();
+    expect(nextMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should generate _internalId for nodes without existing _internalId', async () => {
+    const mockNodes = [
+      { id: 'node1', position: { x: 0, y: 0 }, data: {} },
+      { id: 'node2', position: { x: 10, y: 10 }, data: {} },
+    ];
+
+    context.helpers.anyNodesAdded = vi.fn().mockReturnValue(true);
+    context.initialUpdate = { nodesToAdd: mockNodes };
+
+    await internalIdMiddleware.execute(context, nextMock, () => null);
+
+    expect(nextMock).toHaveBeenCalledTimes(1);
+    const stateUpdate = nextMock.mock.calls[0][0];
+
+    expect(stateUpdate).toBeDefined();
+    expect(stateUpdate.nodesToAdd).toHaveLength(2);
+
+    // Check that _internalId was generated with correct format
+    expect(stateUpdate.nodesToAdd![0]._internalId).toMatch(
+      /^node1-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    );
+    expect(stateUpdate.nodesToAdd![1]._internalId).toMatch(
+      /^node2-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    );
+
+    // Check that other properties are preserved
+    expect(stateUpdate.nodesToAdd![0].id).toBe('node1');
+    expect(stateUpdate.nodesToAdd![0].position).toEqual({ x: 0, y: 0 });
+    expect(stateUpdate.nodesToAdd![1].id).toBe('node2');
+    expect(stateUpdate.nodesToAdd![1].position).toEqual({ x: 10, y: 10 });
+  });
+
+  it('should preserve existing _internalId if already present', async () => {
+    const mockNodes = [
+      {
+        id: 'node1',
+        position: { x: 0, y: 0 },
+        data: {},
+        _internalId: 'existing-internal-id',
+      },
+    ];
+
+    context.helpers.anyNodesAdded = vi.fn().mockReturnValue(true);
+    context.initialUpdate = { nodesToAdd: mockNodes };
+
+    await internalIdMiddleware.execute(context, nextMock, () => null);
+
+    expect(nextMock).toHaveBeenCalledTimes(1);
+    const stateUpdate = nextMock.mock.calls[0][0];
+
+    expect(stateUpdate.nodesToAdd![0]._internalId).toBe('existing-internal-id');
+  });
+
+  it('should generate unique _internalIds for multiple nodes', async () => {
+    const mockNodes = [
+      { id: 'node1', position: { x: 0, y: 0 }, data: {} },
+      { id: 'node1', position: { x: 10, y: 10 }, data: {} }, // Same id, different position
+    ];
+
+    context.helpers.anyNodesAdded = vi.fn().mockReturnValue(true);
+    context.initialUpdate = { nodesToAdd: mockNodes };
+
+    // Mock different UUIDs for sequential calls
+    const randomUUIDMock = vi
+      .spyOn(globalThis.crypto!, 'randomUUID')
+      .mockReturnValueOnce('550e8400-e29b-41d4-a716-446655440000')
+      .mockReturnValueOnce('6ba7b810-9dad-11d1-80b4-00c04fd430c8');
+
+    await internalIdMiddleware.execute(context, nextMock, () => null);
+
+    expect(nextMock).toHaveBeenCalledTimes(1);
+    const stateUpdate = nextMock.mock.calls[0][0];
+
+    expect(stateUpdate.nodesToAdd![0]._internalId).toBeDefined();
+    expect(stateUpdate.nodesToAdd![1]._internalId).toBeDefined();
+    expect(stateUpdate.nodesToAdd![0]._internalId).not.toBe(stateUpdate.nodesToAdd![1]._internalId);
+
+    randomUUIDMock.mockRestore();
+  });
+
+  it('should preserve other initialUpdate properties', async () => {
+    const mockNodes = [{ id: 'node1', position: { x: 0, y: 0 }, data: {} }];
+
+    context.helpers.anyNodesAdded = vi.fn().mockReturnValue(true);
+    context.initialUpdate = {
+      nodesToAdd: mockNodes,
+      edgesToAdd: [{ id: 'edge1', source: 'node1', target: 'node2', data: {} }],
+      metadataUpdate: { viewport: { x: 100, y: 100, scale: 1.5 } },
+    };
+
+    await internalIdMiddleware.execute(context, nextMock, () => null);
+
+    expect(nextMock).toHaveBeenCalledTimes(1);
+    const stateUpdate = nextMock.mock.calls[0][0];
+
+    expect(stateUpdate.nodesToAdd).toBeDefined();
+    expect(stateUpdate.edgesToAdd).toEqual(context.initialUpdate.edgesToAdd);
+    expect(stateUpdate.metadataUpdate).toEqual(context.initialUpdate.metadataUpdate);
+  });
+
+  it('should handle empty nodesToAdd array', async () => {
+    context.helpers.anyNodesAdded = vi.fn().mockReturnValue(true);
+    context.initialUpdate = { nodesToAdd: [] };
+
+    await internalIdMiddleware.execute(context, nextMock, () => null);
+
+    expect(nextMock).toHaveBeenCalledTimes(1);
+    const stateUpdate = nextMock.mock.calls[0][0];
+
+    expect(stateUpdate.nodesToAdd).toEqual([]);
+  });
+
+  it('should handle undefined nodesToAdd', async () => {
+    context.helpers.anyNodesAdded = vi.fn().mockReturnValue(true);
+    context.initialUpdate = {};
+
+    await internalIdMiddleware.execute(context, nextMock, () => null);
+
+    expect(nextMock).toHaveBeenCalledTimes(1);
+    const stateUpdate = nextMock.mock.calls[0][0];
+
+    expect(stateUpdate.nodesToAdd).toBeUndefined();
+  });
+
+  it('should generate _internalId with correct UUID format', async () => {
+    const mockNodes = [{ id: 'test-node', position: { x: 0, y: 0 }, data: {} }];
+
+    context.helpers.anyNodesAdded = vi.fn().mockReturnValue(true);
+    context.initialUpdate = { nodesToAdd: mockNodes };
+
+    // Use a predictable UUID so the regex is deterministic
+    const randomUUIDMock = vi
+      .spyOn(globalThis.crypto!, 'randomUUID')
+      .mockReturnValue('550e8400-e29b-41d4-a716-446655440000');
+
+    await internalIdMiddleware.execute(context, nextMock, () => null);
+
+    const stateUpdate = nextMock.mock.calls[0][0];
+    const internalId = stateUpdate.nodesToAdd![0]._internalId as string;
+
+    // Should match pattern: nodeId-uuid
+    const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+    const fullPattern = /^test-node-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+    expect(internalId).toMatch(fullPattern);
+
+    // Extract UUID part and verify it's a valid UUID
+    const uuidPart = internalId.replace('test-node-', '');
+    expect(uuidPart).toMatch(uuidPattern);
+
+    randomUUIDMock.mockRestore();
+  });
+
+  it('should handle nodes with complex data structures', async () => {
+    const mockNodes = [
+      {
+        id: 'complex-node',
+        position: { x: 100, y: 200 },
+        data: {
+          label: 'Test Node',
+          metadata: { type: 'custom', version: 1 },
+          nested: { deep: { value: 'test' } },
+        },
+        type: 'custom',
+        selected: true,
+        size: { width: 100, height: 50 },
+      },
+    ];
+
+    context.helpers.anyNodesAdded = vi.fn().mockReturnValue(true);
+    context.initialUpdate = { nodesToAdd: mockNodes };
+
+    await internalIdMiddleware.execute(context, nextMock, () => null);
+
+    expect(nextMock).toHaveBeenCalledTimes(1);
+    const stateUpdate = nextMock.mock.calls[0][0];
+
+    expect(stateUpdate.nodesToAdd![0]._internalId).toBeDefined();
+    expect(stateUpdate.nodesToAdd![0]._internalId).toMatch(
+      /^complex-node-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    );
+
+    // Verify all other properties are preserved
+    expect(stateUpdate.nodesToAdd![0].id).toBe('complex-node');
+    expect(stateUpdate.nodesToAdd![0].position).toEqual({ x: 100, y: 200 });
+    expect(stateUpdate.nodesToAdd![0].data).toEqual(mockNodes[0].data);
+    expect(stateUpdate.nodesToAdd![0].type).toBe('custom');
+    expect(stateUpdate.nodesToAdd![0].selected).toBe(true);
+    expect(stateUpdate.nodesToAdd![0].size).toEqual({ width: 100, height: 50 });
+  });
+
+  it('should handle mixed nodes with and without existing _internalId', async () => {
+    const mockNodes = [
+      { id: 'node1', position: { x: 0, y: 0 }, data: {} },
+      {
+        id: 'node2',
+        position: { x: 10, y: 10 },
+        data: {},
+        _internalId: 'preserved-id',
+      },
+      { id: 'node3', position: { x: 20, y: 20 }, data: {} },
+    ];
+
+    context.helpers.anyNodesAdded = vi.fn().mockReturnValue(true);
+    context.initialUpdate = { nodesToAdd: mockNodes };
+
+    // Mock different UUIDs
+    const randomUUIDMock = vi
+      .spyOn(globalThis.crypto!, 'randomUUID')
+      .mockReturnValueOnce('550e8400-e29b-41d4-a716-446655440000')
+      .mockReturnValueOnce('6ba7b810-9dad-11d1-80b4-00c04fd430c8');
+
+    await internalIdMiddleware.execute(context, nextMock, () => null);
+
+    expect(nextMock).toHaveBeenCalledTimes(1);
+    const stateUpdate = nextMock.mock.calls[0][0];
+
+    expect(stateUpdate.nodesToAdd![0]._internalId).toMatch(
+      /^node1-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    );
+    expect(stateUpdate.nodesToAdd![1]._internalId).toBe('preserved-id');
+    expect(stateUpdate.nodesToAdd![2]._internalId).toMatch(
+      /^node3-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    );
+
+    randomUUIDMock.mockRestore();
+  });
+});

--- a/packages/ng-diagram/projects/ng-diagram/src/core/src/middleware-manager/middlewares/internal-id-assignment/internal-id-assignment.ts
+++ b/packages/ng-diagram/projects/ng-diagram/src/core/src/middleware-manager/middlewares/internal-id-assignment/internal-id-assignment.ts
@@ -1,0 +1,35 @@
+import { FlowStateUpdate, Middleware } from '../../../types';
+
+/**
+ * Middleware that automatically generates _internalId for nodes when they are added to the diagram.
+ *
+ * The _internalId is used by Angular's trackBy function to force view recreation when nodes
+ * with the same id are deleted and re-added. This ensures that ng-diagram-port components
+ * properly reinitialize and ports get measured correctly, enabling proper link creation.
+ * @internal
+ */
+export const internalIdMiddleware: Middleware = {
+  name: 'internal-id-assignment',
+  execute: async (context, next) => {
+    const { helpers, initialUpdate } = context;
+
+    if (!helpers.anyNodesAdded()) {
+      next();
+      return;
+    }
+
+    const nodesToAdd = initialUpdate.nodesToAdd?.map((node) => ({
+      ...node,
+      _internalId:
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (node as any)._internalId || `${node.id}-${crypto.randomUUID()}`,
+    }));
+
+    const stateUpdate: FlowStateUpdate = {
+      ...initialUpdate,
+      ...(nodesToAdd ? { nodesToAdd } : {}),
+    };
+
+    next(stateUpdate);
+  },
+};

--- a/packages/ng-diagram/projects/ng-diagram/src/lib/components/diagram/ng-diagram.component.html
+++ b/packages/ng-diagram/projects/ng-diagram/src/lib/components/diagram/ng-diagram.component.html
@@ -12,7 +12,7 @@
     </ng-diagram-edge>
   }
   <ng-diagram-marker-arrow />
-  @for (node of nodes(); track node.id) {
+  @for (node of nodes(); track trackNode($index, node)) {
     <ng-diagram-node class="ng-diagram-node" [attr.data-node-id]="node.id" [node]="node">
       @if (getNodeTemplate(node.type)) {
         <ng-container *ngComponentOutlet="getNodeTemplate(node.type); inputs: { node }" />

--- a/packages/ng-diagram/projects/ng-diagram/src/lib/components/diagram/ng-diagram.component.ts
+++ b/packages/ng-diagram/projects/ng-diagram/src/lib/components/diagram/ng-diagram.component.ts
@@ -215,6 +215,10 @@ export class NgDiagramComponent implements OnInit, OnDestroy {
     return this.edgeTemplateMap().get(edgeType) ?? null;
   }
 
+  // Used by template @for track function to force view recreation after delete/re-add
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  trackNode = (_index: number, node: Node) => (node as any)._internalId || node.id;
+
   isGroup(node: Node) {
     return 'isGroup' in node;
   }

--- a/packages/ng-diagram/projects/ng-diagram/src/lib/utils/create-middlewares.ts
+++ b/packages/ng-diagram/projects/ng-diagram/src/lib/utils/create-middlewares.ts
@@ -1,6 +1,13 @@
-import { edgesRoutingMiddleware, loggerMiddleware, MiddlewareChain, zIndexMiddleware } from '../../core/src';
+import {
+  edgesRoutingMiddleware,
+  internalIdMiddleware,
+  loggerMiddleware,
+  MiddlewareChain,
+  zIndexMiddleware,
+} from '../../core/src';
 
 export const BUILTIN_MIDDLEWARES = [
+  internalIdMiddleware,
   zIndexMiddleware,
   edgesRoutingMiddleware,
   loggerMiddleware,


### PR DESCRIPTION
- Add middleware to assign per-node `_internalId` during node addition; property to internal use only
- Track nodes by `_internalId` to force view recreation after delete/re-add
- Ensures node/port components reinitialize so ports are measured and links work