### PR TITLE
[AF-316] Remove code section headers from documentation

### DIFF
--- a/apps/docs/src/content/docs/intro/quick-start.mdx
+++ b/apps/docs/src/content/docs/intro/quick-start.mdx
@@ -26,7 +26,6 @@ npm install ng-diagram
 </Aside>
 
 ```css
-/* src/styles.scss */
 @import 'ng-diagram/styles.css';
 ```
 

--- a/apps/docs/src/styles/custom.css
+++ b/apps/docs/src/styles/custom.css
@@ -27,3 +27,14 @@ details.ec-section.github {
 ng-diagram-canvas {
   font-family: 'Poppins', sans-serif;
 }
+
+/* Hide the code block header with three dots while preserving syntax highlighting */
+.expressive-code {
+  .header {
+    display: none;
+  }
+
+  code {
+    border-top: var(--ec-brdWd) solid var(--ec-brdCol);
+  }
+}


### PR DESCRIPTION
- Hide expressive-code block headers (three dots menu) in docs
- Remove unnecessary style comment from quick-start guide
- Preserve syntax highlighting and top border styling