### PR TITLE
AF-351 Set Dark Mode as the default on the docs page

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -93,6 +93,8 @@ export default defineConfig({
       components: {
         SocialIcons: './src/components/social-icons/social-icons.astro',
         PageTitle: './src/components/page-title/page-title.astro',
+        ThemeProvider: './src/components/ForceDarkTheme.astro',
+        ThemeSelect: './src/components/ForceThemeSelect.astro',
       },
     }),
   ],

--- a/apps/docs/src/components/ForceDarkTheme.astro
+++ b/apps/docs/src/components/ForceDarkTheme.astro
@@ -1,0 +1,37 @@
+---
+import { Icon } from '@astrojs/starlight/components';
+---
+
+{/* This is intentionally inlined to avoid FOUC. - custom script */}
+<script is:inline>
+    window.StarlightThemeProvider = (() => {
+        const storedTheme =
+            typeof localStorage !== 'undefined' && localStorage.getItem('starlight-theme');
+        const theme =
+            storedTheme ||
+            'dark'; // dark mode by default
+        document.documentElement.dataset.theme = theme === 'light' ? 'light' : 'dark';
+        return {
+            updatePickers(theme = storedTheme || 'dark') {
+                document.querySelectorAll('starlight-theme-select').forEach((picker) => {
+                    const select = picker.querySelector('select');
+                    if (select) select.value = theme;
+                    /** @type {HTMLTemplateElement | null} */
+                    const tmpl = document.querySelector(`#theme-icons`);
+                    const newIcon = tmpl && tmpl.content.querySelector('.' + theme);
+                    if (newIcon) {
+                        const oldIcon = picker.querySelector('svg.label-icon');
+                        if (oldIcon) {
+                            oldIcon.replaceChildren(...newIcon.cloneNode(true).childNodes);
+                        }
+                    }
+                });
+            },
+        };
+    })();
+</script>
+
+<template id="theme-icons">
+    <Icon name="sun" class="light" />
+    <Icon name="moon" class="dark" />
+</template>

--- a/apps/docs/src/components/ForceThemeSelect.astro
+++ b/apps/docs/src/components/ForceThemeSelect.astro
@@ -1,0 +1,56 @@
+---
+import Select from '@astrojs/starlight/components/Select.astro';
+---
+
+<starlight-theme-select>
+    <Select
+        icon="moon"
+        label={Astro.locals.t('themeSelect.accessibleLabel')}
+        options={[
+            { label: Astro.locals.t('themeSelect.dark'), selected: true, value: 'dark' },
+            { label: Astro.locals.t('themeSelect.light'), selected: false, value: 'light' },
+        ]}
+        width="6.25em"
+    />
+</starlight-theme-select>
+
+<script is:inline>
+    window.StarlightThemeProvider.updatePickers();
+</script>
+
+<script>
+    type Theme = 'dark' | 'light';
+
+    const storageKey = 'starlight-theme';
+
+    const parseTheme = (theme: unknown): Theme =>
+        theme === 'dark' || theme === 'light' ? theme : 'dark';
+
+    const loadTheme = (): Theme =>
+        parseTheme(typeof localStorage !== 'undefined' && localStorage.getItem(storageKey));
+
+    function storeTheme(theme: Theme): void {
+        if (typeof localStorage !== 'undefined') {
+            localStorage.setItem(storageKey, theme === 'light' || theme === 'dark' ? theme : '');
+        }
+    }
+
+    function onThemeChange(theme: Theme): void {
+        (window as any).StarlightThemeProvider.updatePickers(theme);
+        document.documentElement.dataset.theme = theme;
+        storeTheme(theme);
+    }
+
+    class StarlightThemeSelect extends HTMLElement {
+        constructor() {
+            super();
+            onThemeChange(loadTheme());
+            this.querySelector('select')?.addEventListener('change', (e) => {
+                if (e.currentTarget instanceof HTMLSelectElement) {
+                    onThemeChange(parseTheme(e.currentTarget.value));
+                }
+            });
+        }
+    }
+    customElements.define('starlight-theme-select', StarlightThemeSelect);
+</script>


### PR DESCRIPTION
Unfortunately, there isn’t a simple setting to set dark mode as the default :)
The recommended solution is to override the ThemeProvider with a simple script, but that conflicted with the light/dark/auto options in the dropdown, so I had to completely override both the ThemeProvider and ThemeSelect components to make it work :)