### PR TITLE
[AF-387] Configure npm trusted publishing with OIDC

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -20,6 +20,9 @@ jobs:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
@@ -41,8 +44,5 @@ jobs:
         run: cd packages/ng-diagram && pnpm build:prod
 
       - name: Publish to npm
-        run: |
-          cd packages/ng-diagram/dist/ng-diagram
-          npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish
+        working-directory: packages/ng-diagram/dist/ng-diagram


### PR DESCRIPTION
- Add npm upgrade step to ensure npm 11.5.1+ (required for OIDC)
- Remove NODE_AUTH_TOKEN secret (replaced by short-lived OIDC tokens)
- Remove --provenance flag (automatic with trusted publishing)
- Remove --access public flag (default for unscoped packages)
- Use working-directory instead of inline cd