### PR TITLE
feat: add built-in self loop edge routing support

### DIFF
--- a/apps/angular-demo/src/app/data/default-model.ts
+++ b/apps/angular-demo/src/app/data/default-model.ts
@@ -264,5 +264,31 @@ export const defaultModel: DiagramModel = {
       targetPort: 'port-right-1',
       targetArrowhead: 'ng-diagram-arrow',
     },
+    {
+      id: '20',
+      source: '5',
+      target: '5',
+      data: { labelPosition: 0.5 },
+      type: 'labelled-edge',
+    },
+    {
+      id: '21',
+      source: '11',
+      target: '11',
+      data: {},
+    },
+    {
+      id: '22',
+      source: '11',
+      target: '11',
+      data: {},
+    },
+    {
+      id: '23',
+      source: '11',
+      target: '11',
+      data: {},
+      routing: 'self-loop',
+    },
   ],
 };

--- a/packages/ng-diagram/projects/ng-diagram/src/core/src/command-handler/commands/linking/__tests__/utils.test.ts
+++ b/packages/ng-diagram/projects/ng-diagram/src/core/src/command-handler/commands/linking/__tests__/utils.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { Port } from '../../../../types';
+import { isProperTargetPort } from '../utils';
+
+function createTargetPort(overrides?: Partial<Port>): Port {
+  return {
+    id: 'target-port',
+    nodeId: 'target-node',
+    side: 'right',
+    type: 'target',
+    ...overrides,
+  };
+}
+
+describe('isProperTargetPort', () => {
+  it('should reject source-only target ports', () => {
+    const result = isProperTargetPort(createTargetPort({ type: 'source' }), 'source-node', 'source-port');
+    expect(result).toBe(false);
+  });
+
+  it('should allow ports on different nodes', () => {
+    const result = isProperTargetPort(createTargetPort({ nodeId: 'target-node' }), 'source-node', 'source-port');
+    expect(result).toBe(true);
+  });
+
+  it('should allow self-loop targeting a different port on the same node', () => {
+    const result = isProperTargetPort(
+      createTargetPort({ nodeId: 'same-node', id: 'other-port' }),
+      'same-node',
+      'source-port'
+    );
+    expect(result).toBe(true);
+  });
+
+  it('should reject self-loop targeting the same port on the same node', () => {
+    const result = isProperTargetPort(
+      createTargetPort({ nodeId: 'same-node', id: 'source-port' }),
+      'same-node',
+      'source-port'
+    );
+    expect(result).toBe(false);
+  });
+});

--- a/packages/ng-diagram/projects/ng-diagram/src/core/src/command-handler/commands/linking/utils.ts
+++ b/packages/ng-diagram/projects/ng-diagram/src/core/src/command-handler/commands/linking/utils.ts
@@ -17,13 +17,12 @@ export const isProperTargetPort = (targetPort: Port, sourceNodeId?: string, sour
   if (targetPort.type === 'source') {
     return false;
   }
-  if (sourceNodeId && targetPort.nodeId !== sourceNodeId) {
-    return true;
-  }
-  if (sourcePortId && targetPort.id !== sourcePortId) {
-    return true;
-  }
-  return false;
+
+  if (!sourceNodeId) return true;
+  if (targetPort.nodeId !== sourceNodeId) return true;
+  if (!sourcePortId) return false;
+
+  return targetPort.id !== sourcePortId;
 };
 
 export const validateConnection = (

--- a/packages/ng-diagram/projects/ng-diagram/src/core/src/edge-routing-manager/__tests__/edge-routing-manager.test.ts
+++ b/packages/ng-diagram/projects/ng-diagram/src/core/src/edge-routing-manager/__tests__/edge-routing-manager.test.ts
@@ -119,6 +119,7 @@ describe('EdgeRoutingManager', () => {
       expect(routings).toContain('orthogonal');
       expect(routings).toContain('bezier');
       expect(routings).toContain('polyline');
+      expect(routings).toContain('self-loop');
     });
 
     it('should use provided default routing', () => {
@@ -213,7 +214,8 @@ describe('EdgeRoutingManager', () => {
       expect(routings).toContain('orthogonal');
       expect(routings).toContain('bezier');
       expect(routings).toContain('polyline');
-      expect(routings.length).toBe(3);
+      expect(routings).toContain('self-loop');
+      expect(routings.length).toBe(4);
     });
 
     it('should include custom routings', () => {
@@ -223,7 +225,7 @@ describe('EdgeRoutingManager', () => {
       const routings = manager.getRegisteredRoutings();
       expect(routings).toContain('custom1');
       expect(routings).toContain('custom2');
-      expect(routings.length).toBe(5);
+      expect(routings.length).toBe(6);
     });
   });
 
@@ -232,6 +234,7 @@ describe('EdgeRoutingManager', () => {
       expect(manager.hasRouting('orthogonal')).toBe(true);
       expect(manager.hasRouting('bezier')).toBe(true);
       expect(manager.hasRouting('polyline')).toBe(true);
+      expect(manager.hasRouting('self-loop')).toBe(true);
     });
 
     it('should return false for non-existent routings', () => {
@@ -525,6 +528,20 @@ describe('EdgeRoutingManager', () => {
       expect(polylinePath).toContain('M');
       const polylinePoint = manager.computePointOnPath('polyline', polylinePoints, 0.5);
       expect(polylinePoint).toBeDefined();
+
+      // Test self-loop
+      const selfLoopContext: EdgeRoutingContext = {
+        ...context,
+        edge: { id: 'self-loop-edge', source: 'n1', target: 'n1', data: {} },
+        targetNode: context.sourceNode,
+        targetPoint: { x: context.sourcePoint.x + 20, y: context.sourcePoint.y, side: 'top' },
+      };
+      const selfLoopPoints = manager.computePoints('self-loop', selfLoopContext);
+      expect(selfLoopPoints.length).toBeGreaterThanOrEqual(2);
+      const selfLoopPath = manager.computePath('self-loop', selfLoopPoints);
+      expect(selfLoopPath).toContain('M');
+      const selfLoopPoint = manager.computePointOnPath('self-loop', selfLoopPoints, 0.5);
+      expect(selfLoopPoint).toBeDefined();
     });
 
     it('should support custom routing workflow', () => {

--- a/packages/ng-diagram/projects/ng-diagram/src/core/src/edge-routing-manager/edge-routing-manager.ts
+++ b/packages/ng-diagram/projects/ng-diagram/src/core/src/edge-routing-manager/edge-routing-manager.ts
@@ -2,6 +2,7 @@ import { EdgeRoutingConfig, Point } from '../types';
 import { BezierRouting } from './routings/bezier/bezier-routing';
 import { OrthogonalRouting } from './routings/orthogonal/orthogonal-routing';
 import { PolylineRouting } from './routings/polyline/polyline-routing';
+import { SelfLoopRouting } from './routings/self-loop/self-loop-routing';
 import { EdgeRouting, EdgeRoutingContext, EdgeRoutingName } from './types';
 import { computeLinearSegmentLengths, interpolateAlongLinearSegments } from './utils/linear-segment-utils';
 import { normalizeDistance } from './utils/normalize-distance';
@@ -50,7 +51,7 @@ Documentation: https://www.ngdiagram.dev/docs/guides/edges/routing/
  *
  * @category Types/Routing
  */
-export const BUILT_IN_EDGE_ROUTINGS = ['orthogonal', 'bezier', 'polyline'] as const;
+export const BUILT_IN_EDGE_ROUTINGS = ['orthogonal', 'bezier', 'polyline', 'self-loop'] as const;
 
 /**
  * **Internal manager** for registration, selection, and execution of edge routing implementations.
@@ -100,6 +101,7 @@ export class EdgeRoutingManager {
     this.registerRouting(new OrthogonalRouting());
     this.registerRouting(new BezierRouting());
     this.registerRouting(new PolylineRouting());
+    this.registerRouting(new SelfLoopRouting());
   }
 
   /**

--- a/packages/ng-diagram/projects/ng-diagram/src/core/src/edge-routing-manager/index.ts
+++ b/packages/ng-diagram/projects/ng-diagram/src/core/src/edge-routing-manager/index.ts
@@ -4,4 +4,5 @@ export * from './resolve-label-position';
 export * from './routings/bezier/bezier-routing';
 export * from './routings/orthogonal/orthogonal-routing';
 export * from './routings/polyline/polyline-routing';
+export * from './routings/self-loop/self-loop-routing';
 export * from './types';

--- a/packages/ng-diagram/projects/ng-diagram/src/core/src/edge-routing-manager/routings/self-loop/__tests__/self-loop-routing.test.ts
+++ b/packages/ng-diagram/projects/ng-diagram/src/core/src/edge-routing-manager/routings/self-loop/__tests__/self-loop-routing.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { Edge, EdgeRoutingConfig, Node, PortLocation } from '../../../../types';
+import { EdgeRoutingContext } from '../../../types';
+import { SelfLoopRouting } from '../self-loop-routing';
+
+function createContext(overrides?: Partial<EdgeRoutingContext>): EdgeRoutingContext {
+  const sourcePoint: PortLocation = { x: 120, y: 100, side: 'top' };
+  const targetPoint: PortLocation = { x: 160, y: 100, side: 'top' };
+
+  return {
+    sourcePoint,
+    targetPoint,
+    edge: { id: 'loop-1', source: 'node-1', target: 'node-1', data: {} } as Edge,
+    sourceNode: { id: 'node-1', position: { x: 100, y: 100 }, size: { width: 100, height: 80 }, data: {} } as Node,
+    targetNode: { id: 'node-1', position: { x: 100, y: 100 }, size: { width: 100, height: 80 }, data: {} } as Node,
+    ...overrides,
+  };
+}
+
+describe('SelfLoopRouting', () => {
+  it('should generate cubic bezier points for a single self-loop', () => {
+    const routing = new SelfLoopRouting();
+    const points = routing.computePoints(createContext());
+
+    expect(points).toHaveLength(4);
+    expect(points[0].y).toBe(100);
+    expect(points[3].y).toBe(100);
+    expect(points[1].y).toBeLessThan(100);
+    expect(points[2].y).toBeLessThan(100);
+  });
+
+  it('should use side from port data', () => {
+    const routing = new SelfLoopRouting();
+    const points = routing.computePoints(
+      createContext({
+        sourcePoint: { x: 200, y: 120, side: 'right' },
+        targetPoint: { x: 200, y: 160, side: 'right' },
+        sourcePort: { id: 'source', nodeId: 'node-1', side: 'right', type: 'both' },
+        targetPort: { id: 'target', nodeId: 'node-1', side: 'right', type: 'both' },
+      })
+    );
+
+    expect(points).toHaveLength(4);
+    expect(points[0].x).toBe(200);
+    expect(points[3].x).toBe(200);
+    expect(points[1].x).toBeGreaterThan(200);
+    expect(points[2].x).toBeGreaterThan(200);
+  });
+
+  it('should fan out multiple self-loops using selfLoopIndex', () => {
+    const routing = new SelfLoopRouting();
+    const config: EdgeRoutingConfig = {
+      defaultRouting: 'orthogonal',
+      selfLoop: { loopSize: 40, loopSpread: 24, sizeIncrement: 10, defaultSide: 'top' },
+    };
+
+    const firstLoop = routing.computePoints(createContext({ selfLoopIndex: 0, selfLoopCount: 3 }), config);
+    const secondLoop = routing.computePoints(createContext({ selfLoopIndex: 1, selfLoopCount: 3 }), config);
+    const thirdLoop = routing.computePoints(createContext({ selfLoopIndex: 2, selfLoopCount: 3 }), config);
+
+    expect(firstLoop).not.toEqual(secondLoop);
+    expect(secondLoop).not.toEqual(thirdLoop);
+  });
+
+  it('should generate a valid svg cubic path', () => {
+    const routing = new SelfLoopRouting();
+    const points = routing.computePoints(createContext());
+    const path = routing.computeSvgPath(points);
+
+    expect(path).toContain('M ');
+    expect(path).toContain(' C ');
+  });
+
+  it('should compute point on path and at distance', () => {
+    const routing = new SelfLoopRouting();
+    const points = routing.computePoints(createContext());
+
+    const midpoint = routing.computePointOnPath(points, 0.5);
+    const pointAtDistance = routing.computePointAtDistance(points, 20);
+
+    expect(midpoint).toHaveProperty('x');
+    expect(midpoint).toHaveProperty('y');
+    expect(pointAtDistance).toHaveProperty('x');
+    expect(pointAtDistance).toHaveProperty('y');
+  });
+});

--- a/packages/ng-diagram/projects/ng-diagram/src/core/src/edge-routing-manager/routings/self-loop/self-loop-routing.ts
+++ b/packages/ng-diagram/projects/ng-diagram/src/core/src/edge-routing-manager/routings/self-loop/self-loop-routing.ts
@@ -1,0 +1,105 @@
+import { EdgeRoutingConfig, Point, PortLocation, PortSide } from '../../../types';
+import { EdgeRouting, EdgeRoutingContext } from '../../types';
+import { computeBezierPath } from '../bezier/compute-bezier-path';
+import { computeBezierPointAtDistance } from '../bezier/compute-bezier-point-at-distance';
+import { computeBezierPointOnPath } from '../bezier/compute-bezier-point-on-path';
+
+const LOOP_SIZE_FALLBACK = 50;
+const LOOP_SPREAD_FALLBACK = 30;
+const LOOP_SIZE_INCREMENT_FALLBACK = 25;
+const DEFAULT_SIDE_FALLBACK: PortSide = 'top';
+const SIDES: PortSide[] = ['top', 'right', 'bottom', 'left'];
+
+function getRotatedSide(baseSide: PortSide, index: number): PortSide {
+  const baseIndex = SIDES.indexOf(baseSide);
+  if (baseIndex === -1) return baseSide;
+  const normalizedIndex = ((index % SIDES.length) + SIDES.length) % SIDES.length;
+  return SIDES[(baseIndex + normalizedIndex) % SIDES.length];
+}
+
+function getSideForLoop(context: EdgeRoutingContext, defaultSide: PortSide): PortSide {
+  const sourcePortSide = context.sourcePort?.side;
+  const targetPortSide = context.targetPort?.side;
+  const sourcePointSide = context.sourcePoint.side;
+
+  if (sourcePortSide && sourcePortSide === targetPortSide) return sourcePortSide;
+  if (sourcePortSide) return sourcePortSide;
+  if (targetPortSide) return targetPortSide;
+  if (sourcePointSide) return sourcePointSide;
+  return defaultSide;
+}
+
+function getSelfLoopPoints(
+  sourcePoint: PortLocation,
+  targetPoint: PortLocation,
+  loopSide: PortSide,
+  loopSize: number,
+  loopSpread: number
+): Point[] {
+  const centerX = (sourcePoint.x + targetPoint.x) / 2;
+  const centerY = (sourcePoint.y + targetPoint.y) / 2;
+  const halfSpread = loopSpread / 2;
+
+  switch (loopSide) {
+    case 'right':
+      return [
+        { x: centerX, y: centerY - halfSpread },
+        { x: centerX + loopSize, y: centerY - halfSpread },
+        { x: centerX + loopSize, y: centerY + halfSpread },
+        { x: centerX, y: centerY + halfSpread },
+      ];
+    case 'bottom':
+      return [
+        { x: centerX + halfSpread, y: centerY },
+        { x: centerX + halfSpread, y: centerY + loopSize },
+        { x: centerX - halfSpread, y: centerY + loopSize },
+        { x: centerX - halfSpread, y: centerY },
+      ];
+    case 'left':
+      return [
+        { x: centerX, y: centerY + halfSpread },
+        { x: centerX - loopSize, y: centerY + halfSpread },
+        { x: centerX - loopSize, y: centerY - halfSpread },
+        { x: centerX, y: centerY - halfSpread },
+      ];
+    case 'top':
+    default:
+      return [
+        { x: centerX - halfSpread, y: centerY },
+        { x: centerX - halfSpread, y: centerY - loopSize },
+        { x: centerX + halfSpread, y: centerY - loopSize },
+        { x: centerX + halfSpread, y: centerY },
+      ];
+  }
+}
+
+export class SelfLoopRouting implements EdgeRouting {
+  name = 'self-loop';
+
+  computePoints(context: EdgeRoutingContext, config?: EdgeRoutingConfig): Point[] {
+    const loopSize = config?.selfLoop?.loopSize ?? LOOP_SIZE_FALLBACK;
+    const loopSpread = config?.selfLoop?.loopSpread ?? LOOP_SPREAD_FALLBACK;
+    const loopSizeIncrement = config?.selfLoop?.sizeIncrement ?? LOOP_SIZE_INCREMENT_FALLBACK;
+    const defaultSide = config?.selfLoop?.defaultSide ?? DEFAULT_SIDE_FALLBACK;
+    const selfLoopIndex = context.selfLoopIndex ?? 0;
+
+    const baseSide = getSideForLoop(context, defaultSide);
+    const loopSide = getRotatedSide(baseSide, selfLoopIndex);
+    const computedLoopSize = Math.max(0, loopSize + selfLoopIndex * loopSizeIncrement);
+    const computedLoopSpread = Math.max(1, loopSpread + selfLoopIndex * 8);
+
+    return getSelfLoopPoints(context.sourcePoint, context.targetPoint, loopSide, computedLoopSize, computedLoopSpread);
+  }
+
+  computeSvgPath(points: Point[]): string {
+    return computeBezierPath(points);
+  }
+
+  computePointOnPath(points: Point[], percentage: number): Point {
+    return computeBezierPointOnPath(points, percentage);
+  }
+
+  computePointAtDistance(points: Point[], distancePx: number): Point {
+    return computeBezierPointAtDistance(points, distancePx);
+  }
+}

--- a/packages/ng-diagram/projects/ng-diagram/src/core/src/edge-routing-manager/types.ts
+++ b/packages/ng-diagram/projects/ng-diagram/src/core/src/edge-routing-manager/types.ts
@@ -60,6 +60,16 @@ export interface EdgeRoutingContext {
    * Target port (if edge is connected to a specific port)
    */
   targetPort?: Port;
+
+  /**
+   * Zero-based index of this self-loop among sibling self-loops on the same node.
+   */
+  selfLoopIndex?: number;
+
+  /**
+   * Total number of self-loops on the same node.
+   */
+  selfLoopCount?: number;
 }
 
 /**

--- a/packages/ng-diagram/projects/ng-diagram/src/core/src/flow-config/default-flow-config.ts
+++ b/packages/ng-diagram/projects/ng-diagram/src/core/src/flow-config/default-flow-config.ts
@@ -127,6 +127,12 @@ const defaultEdgeRoutingConfig: EdgeRoutingConfig = {
     maxCornerRadius: 15,
     firstLastSegmentLength: 20,
   },
+  selfLoop: {
+    loopSize: 50,
+    loopSpread: 30,
+    defaultSide: 'top',
+    sizeIncrement: 25,
+  },
 };
 
 const defaultBoxSelectionConfig: BoxSelectionConfig = {

--- a/packages/ng-diagram/projects/ng-diagram/src/core/src/middleware-manager/middlewares/edges-routing/__tests__/edges-routing.test.ts
+++ b/packages/ng-diagram/projects/ng-diagram/src/core/src/middleware-manager/middlewares/edges-routing/__tests__/edges-routing.test.ts
@@ -5,6 +5,7 @@ import { mockEdge, mockMetadata, mockNode } from '../../../../test-utils';
 import type { Edge, FlowState, MiddlewareContext } from '../../../../types';
 import { DEFAULT_SELECTED_Z_INDEX } from '../../z-index-assignment/constants';
 import { edgesRoutingMiddleware } from '../edges-routing';
+import { getEdgePoints } from '../get-edge-points';
 
 vi.mock('../get-edge-points', () => ({
   getEdgePoints: vi.fn().mockImplementation((edge) => {
@@ -39,6 +40,7 @@ describe('Edges Routing Middleware', () => {
 
   const nodesMap = new Map();
   const edgesMap = new Map();
+  const mockGetEdgePoints = vi.mocked(getEdgePoints);
 
   const mockRoutingManager: Partial<EdgeRoutingManager> = {
     hasRouting: vi.fn().mockReturnValue(true),
@@ -326,6 +328,40 @@ describe('Edges Routing Middleware', () => {
       edgesRoutingMiddleware.execute(context as any, nextMock, () => null);
 
       expect(nextMock).toHaveBeenCalledWith({});
+    });
+
+    it('should pass self-loop metadata to getEdgePoints for sibling loops', () => {
+      const newState = {
+        nodes: [{ ...mockNode, id: 'node-1', position: { x: 100, y: 100 } }],
+        edges: [
+          {
+            ...mockEdge,
+            id: 'self-loop-1',
+            source: 'node-1',
+            target: 'node-1',
+          },
+          {
+            ...mockEdge,
+            id: 'self-loop-2',
+            source: 'node-1',
+            target: 'node-1',
+          },
+        ],
+        metadata: mockMetadata,
+      };
+
+      nodesMap.clear();
+      newState.nodes.forEach((node) => nodesMap.set(node.id, node));
+      context.state = newState;
+      context.modelActionTypes = ['init'];
+
+      edgesRoutingMiddleware.execute(context as any, nextMock, () => null);
+
+      const selfLoop1Call = mockGetEdgePoints.mock.calls.find((call) => call[0].id === 'self-loop-1');
+      const selfLoop2Call = mockGetEdgePoints.mock.calls.find((call) => call[0].id === 'self-loop-2');
+
+      expect(selfLoop1Call?.[3]).toEqual({ index: 0, count: 2 });
+      expect(selfLoop2Call?.[3]).toEqual({ index: 1, count: 2 });
     });
   });
 

--- a/packages/ng-diagram/projects/ng-diagram/src/core/src/middleware-manager/middlewares/edges-routing/__tests__/get-edge-points.test.ts
+++ b/packages/ng-diagram/projects/ng-diagram/src/core/src/middleware-manager/middlewares/edges-routing/__tests__/get-edge-points.test.ts
@@ -370,6 +370,27 @@ describe('getEdgePoints', () => {
         { x: 90, y: 90 },
       ]);
     });
+
+    it('should auto-use self-loop routing for self-loop edges', () => {
+      const edge: Edge = {
+        ...mockEdge,
+        id: 'self-loop-edge',
+        source: 'node-1',
+        target: 'node-1',
+      };
+
+      nodesMap.set('node-1', { ...mockNode, id: 'node-1', position: { x: 100, y: 100 } });
+      mockRoutingManager.hasRouting = vi.fn().mockImplementation((routing) => routing === 'self-loop');
+
+      getEdgePoints(edge, nodesMap, mockRoutingManager as EdgeRoutingManager);
+
+      expect(mockRoutingManager.computePoints).toHaveBeenCalledWith(
+        'self-loop',
+        expect.objectContaining({
+          edge,
+        })
+      );
+    });
   });
 
   describe('Edge Context Building', () => {
@@ -452,6 +473,27 @@ describe('getEdgePoints', () => {
       expect(result.sourcePoint).toEqual({ x: 0, y: 0 });
       expect(result.targetPoint).toEqual({ x: 100, y: 100 });
       expect(result.points).toHaveLength(3);
+    });
+
+    it('should pass self-loop metadata in routing context', () => {
+      const edge: Edge = {
+        ...mockEdge,
+        id: 'self-loop-edge',
+        source: 'node-1',
+        target: 'node-1',
+      };
+
+      nodesMap.set('node-1', { ...mockNode, id: 'node-1', position: { x: 0, y: 0 } });
+
+      getEdgePoints(edge, nodesMap, mockRoutingManager as EdgeRoutingManager, { index: 2, count: 4 });
+
+      expect(mockRoutingManager.computePoints).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          selfLoopIndex: 2,
+          selfLoopCount: 4,
+        })
+      );
     });
   });
 

--- a/packages/ng-diagram/projects/ng-diagram/src/core/src/middleware-manager/middlewares/edges-routing/__tests__/get-source-target-positions.test.ts
+++ b/packages/ng-diagram/projects/ng-diagram/src/core/src/middleware-manager/middlewares/edges-routing/__tests__/get-source-target-positions.test.ts
@@ -170,6 +170,78 @@ describe('getSourceTargetPositions', () => {
     expect(result.target).toEqual({ x: 205, y: 50, side: 'left' });
   });
 
+  it('should return distinct synthetic points for self-loop without ports', () => {
+    const edge: Edge = {
+      ...mockEdge,
+      source: 'node-1',
+      target: 'node-1',
+    };
+
+    const nodesMap = new Map<string, Node>([
+      [
+        'node-1',
+        {
+          ...mockNode,
+          id: 'node-1',
+          position: { x: 100, y: 100 },
+          size: { width: 100, height: 80 },
+        },
+      ],
+    ]);
+
+    const result = getSourceTargetPositions(edge, nodesMap);
+
+    expect(result.source).toBeDefined();
+    expect(result.target).toBeDefined();
+    expect(result.source?.side).toBe('top');
+    expect(result.target?.side).toBe('top');
+    expect(result.source?.x).not.toBe(result.target?.x);
+    expect(result.source?.y).toBe(result.target?.y);
+  });
+
+  it('should use distinct same-node ports for self-loop', () => {
+    const edge: Edge = {
+      ...mockEdge,
+      source: 'node-1',
+      target: 'node-1',
+      sourcePort: 'source-port',
+      targetPort: 'target-port',
+    };
+
+    const nodesMap = new Map<string, Node>([
+      [
+        'node-1',
+        {
+          ...mockNode,
+          id: 'node-1',
+          position: { x: 100, y: 100 },
+          size: { width: 100, height: 80 },
+          measuredPorts: [
+            {
+              ...mockPort,
+              id: 'source-port',
+              side: 'right',
+              position: { x: 90, y: 20 },
+              size: { width: 10, height: 10 },
+            },
+            {
+              ...mockPort,
+              id: 'target-port',
+              side: 'bottom',
+              position: { x: 30, y: 70 },
+              size: { width: 10, height: 10 },
+            },
+          ],
+        },
+      ],
+    ]);
+
+    const result = getSourceTargetPositions(edge, nodesMap);
+
+    expect(result.source).toEqual({ x: 195, y: 125, side: 'right' });
+    expect(result.target).toEqual({ x: 135, y: 175, side: 'bottom' });
+  });
+
   it('should handle rotated nodes with ports', () => {
     const edge: Edge = {
       ...mockEdge,

--- a/packages/ng-diagram/projects/ng-diagram/src/core/src/middleware-manager/middlewares/edges-routing/edges-routing.ts
+++ b/packages/ng-diagram/projects/ng-diagram/src/core/src/middleware-manager/middlewares/edges-routing/edges-routing.ts
@@ -4,6 +4,27 @@ import { isSamePoint, isValidPosition } from '../../../utils';
 import { DEFAULT_SELECTED_Z_INDEX } from '../z-index-assignment';
 import { getEdgePoints } from './get-edge-points';
 
+const getSelfLoopMetadataByEdgeId = (edges: Edge[]): Map<string, { index: number; count: number }> => {
+  const selfLoopMetadataByEdgeId = new Map<string, { index: number; count: number }>();
+  const selfLoopsByNodeId = new Map<string, Edge[]>();
+
+  edges.forEach((edge) => {
+    if (edge.source !== edge.target || edge.source === '') return;
+    const loopEdges = selfLoopsByNodeId.get(edge.source) ?? [];
+    loopEdges.push(edge);
+    selfLoopsByNodeId.set(edge.source, loopEdges);
+  });
+
+  selfLoopsByNodeId.forEach((loopEdges) => {
+    const count = loopEdges.length;
+    loopEdges.forEach((edge, index) => {
+      selfLoopMetadataByEdgeId.set(edge.id, { index, count });
+    });
+  });
+
+  return selfLoopMetadataByEdgeId;
+};
+
 /**
  * Determines if edges should be re-routed based on changes in the flow state.
  */
@@ -141,13 +162,19 @@ export const processEdgesForRouting = (
   modelActionTypes: MiddlewareContext['modelActionTypes']
 ): NonNullable<FlowStateUpdate['edgesToUpdate']> => {
   const edgesToUpdate: NonNullable<FlowStateUpdate['edgesToUpdate']> = [];
+  const selfLoopMetadataByEdgeId = getSelfLoopMetadataByEdgeId(edges);
 
   edges.forEach((edge) => {
     if (!shouldRouteEdge(edge, helpers, modelActionTypes)) {
       return;
     }
 
-    const { sourcePoint, targetPoint, points } = getEdgePoints(edge, nodesMap, routingManager);
+    const { sourcePoint, targetPoint, points } = getEdgePoints(
+      edge,
+      nodesMap,
+      routingManager,
+      selfLoopMetadataByEdgeId.get(edge.id)
+    );
 
     // Skip if we don't have valid points (e.g., ports not initialized)
     if (!points || points.length === 0) {

--- a/packages/ng-diagram/projects/ng-diagram/src/core/src/middleware-manager/middlewares/edges-routing/get-edge-points.ts
+++ b/packages/ng-diagram/projects/ng-diagram/src/core/src/middleware-manager/middlewares/edges-routing/get-edge-points.ts
@@ -88,7 +88,8 @@ export const computeAutoModePoints = (
   target: PortLocation,
   sourceNode: Node | undefined,
   targetNode: Node | undefined,
-  routingManager: EdgeRoutingManager
+  routingManager: EdgeRoutingManager,
+  selfLoopMetadata?: { index: number; count: number }
 ): Point[] => {
   const context: EdgeRoutingContext = {
     sourcePoint: source,
@@ -98,10 +99,15 @@ export const computeAutoModePoints = (
     targetNode,
     sourcePort: findNodePort(sourceNode, edge.sourcePort),
     targetPort: findNodePort(targetNode, edge.targetPort),
+    selfLoopIndex: selfLoopMetadata?.index,
+    selfLoopCount: selfLoopMetadata?.count,
   };
 
-  if (edge.routing && routingManager.hasRouting(edge.routing)) {
-    return routingManager.computePoints(edge.routing, context);
+  const hasSelfLoop = edge.source === edge.target && edge.source !== '';
+  const effectiveRouting = edge.routing || (hasSelfLoop ? 'self-loop' : undefined);
+
+  if (effectiveRouting && routingManager.hasRouting(effectiveRouting)) {
+    return routingManager.computePoints(effectiveRouting, context);
   }
 
   // Warn if edge specified a routing that wasn't registered
@@ -122,7 +128,12 @@ export const computeAutoModePoints = (
 /**
  * Gets edge points based on routing mode and configuration.
  */
-export const getEdgePoints = (edge: Edge, nodesMap: Map<string, Node>, routingManager: EdgeRoutingManager) => {
+export const getEdgePoints = (
+  edge: Edge,
+  nodesMap: Map<string, Node>,
+  routingManager: EdgeRoutingManager,
+  selfLoopMetadata?: { index: number; count: number }
+) => {
   const sourceNode = nodesMap.get(edge.source);
   const targetNode = nodesMap.get(edge.target);
 
@@ -149,7 +160,7 @@ export const getEdgePoints = (edge: Edge, nodesMap: Map<string, Node>, routingMa
   const points =
     isManualMode && hasManualPoints
       ? edge.points // Use user-provided points for manual mode
-      : computeAutoModePoints(edge, source, target, sourceNode, targetNode, routingManager);
+      : computeAutoModePoints(edge, source, target, sourceNode, targetNode, routingManager, selfLoopMetadata);
 
   return { sourcePoint, targetPoint, points };
 };

--- a/packages/ng-diagram/projects/ng-diagram/src/core/src/middleware-manager/middlewares/edges-routing/get-source-target-positions.ts
+++ b/packages/ng-diagram/projects/ng-diagram/src/core/src/middleware-manager/middlewares/edges-routing/get-source-target-positions.ts
@@ -28,6 +28,47 @@ const getTemporaryEdgeSides = (
   return {};
 };
 
+function arePointsEqual(firstPoint: Point, secondPoint: Point): boolean {
+  return firstPoint.x === secondPoint.x && firstPoint.y === secondPoint.y;
+}
+
+function getSelfLoopSide(edge: Edge, sourceSide?: PortSide, targetSide?: PortSide): PortSide {
+  return sourceSide ?? targetSide ?? (edge.sourcePosition ? 'right' : 'top');
+}
+
+function computeSyntheticSelfLoopPositions(node: Node, side: PortSide): { source: PortLocation; target: PortLocation } {
+  const width = node.size?.width ?? 0;
+  const height = node.size?.height ?? 0;
+  const centerX = node.position.x + width / 2;
+  const centerY = node.position.y + height / 2;
+  const spread = Math.max(12, Math.min(width, height, 24));
+  const halfSpread = spread / 2;
+
+  switch (side) {
+    case 'right':
+      return {
+        source: { x: node.position.x + width, y: centerY - halfSpread, side },
+        target: { x: node.position.x + width, y: centerY + halfSpread, side },
+      };
+    case 'bottom':
+      return {
+        source: { x: centerX - halfSpread, y: node.position.y + height, side },
+        target: { x: centerX + halfSpread, y: node.position.y + height, side },
+      };
+    case 'left':
+      return {
+        source: { x: node.position.x, y: centerY - halfSpread, side },
+        target: { x: node.position.x, y: centerY + halfSpread, side },
+      };
+    case 'top':
+    default:
+      return {
+        source: { x: centerX - halfSpread, y: node.position.y, side },
+        target: { x: centerX + halfSpread, y: node.position.y, side },
+      };
+  }
+}
+
 /**
  * Calculates and returns the source and target positions for a given edge based on the connected nodes.
  *
@@ -48,6 +89,24 @@ export const getSourceTargetPositions = (edge: Edge, nodesMap: Map<string, Node>
 
   const preliminarySourcePoint = getPreliminaryPosition(sourceNode, edge.sourcePort, edge.sourcePosition);
   const preliminaryTargetPoint = getPreliminaryPosition(targetNode, edge.targetPort, edge.targetPosition);
+
+  const isSelfLoopEdge = edge.source === edge.target && !!sourceNode;
+  if (isSelfLoopEdge && sourceNode) {
+    const sourcePortLocation = edge.sourcePort ? getPortFlowPositionSide(sourceNode, edge.sourcePort) : undefined;
+    const targetPortLocation = edge.targetPort ? getPortFlowPositionSide(sourceNode, edge.targetPort) : undefined;
+    const hasDistinctPortAnchors =
+      !!sourcePortLocation && !!targetPortLocation && !arePointsEqual(sourcePortLocation, targetPortLocation);
+
+    if (hasDistinctPortAnchors) {
+      return {
+        source: sourcePortLocation,
+        target: targetPortLocation,
+      };
+    }
+
+    const loopSide = getSelfLoopSide(edge, sourcePortLocation?.side, targetPortLocation?.side);
+    return computeSyntheticSelfLoopPositions(sourceNode, loopSide);
+  }
 
   // Second pass: calculate final positions with correct 'from' points for border intersections
   const sourcePoint = getPosition(

--- a/packages/ng-diagram/projects/ng-diagram/src/core/src/types/flow-config.interface.ts
+++ b/packages/ng-diagram/projects/ng-diagram/src/core/src/types/flow-config.interface.ts
@@ -2,7 +2,7 @@ import { EdgeRoutingName } from '../edge-routing-manager';
 import type { Edge } from './edge.interface';
 import type { Node, Port } from './node.interface';
 import type { ShortcutDefinition } from './shortcut.interface';
-import { Size } from './utils';
+import { PortSide, Size } from './utils';
 
 /**
  * Configuration for node resizing behavior.
@@ -389,6 +389,27 @@ export interface EdgeRoutingConfig {
      * @default 15
      */
     maxCornerRadius?: number;
+  };
+
+  /** configuration options for self-loop routing
+   */
+  selfLoop?: {
+    /** Distance that loop extends outward from the node side.
+     * @default 50
+     */
+    loopSize?: number;
+    /** Distance between self-loop start and end anchor points.
+     * @default 30
+     */
+    loopSpread?: number;
+    /** Preferred side for the first self-loop.
+     * @default 'top'
+     */
+    defaultSide?: PortSide;
+    /** Loop size increment for each additional self-loop on the same node.
+     * @default 25
+     */
+    sizeIncrement?: number;
   };
 
   /**


### PR DESCRIPTION
Description:

Implements first-class self-loop support in ng-diagram

What changed:

- Added new built-in self-loop routing
- Added self-loop metadata in routing context (selfLoopIndex, selfLoopCount)
- Added edgeRouting.selfLoop config + defaults
- Updated edge routing flow to detect and route source === target edges correctly
- Updated linking validation to allow valid same-node self-connections
- Added/updated tests and demo self-loop examples

